### PR TITLE
Rundeck API v5 and job logging support

### DIFF
--- a/src/main/java/org/rundeck/api/domain/RundeckOutput.java
+++ b/src/main/java/org/rundeck/api/domain/RundeckOutput.java
@@ -1,0 +1,292 @@
+package org.rundeck.api.domain;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import java.io.Serializable;
+
+import org.rundeck.api.domain.RundeckExecution.ExecutionStatus;
+
+
+/**
+ * Represents a RunDeck output
+ * 
+ */
+public class RundeckOutput implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private Long executionId;
+	
+	//private String message = null;
+
+	//private String error = null;
+	
+	private Boolean unmodified;
+	
+	private Boolean empty;
+	
+	private int offset;
+	
+	private Boolean completed = false;
+	
+	private Boolean execCompleted = false;
+	
+	private Boolean hasFailedNodes = false;
+	
+	private RundeckExecution.ExecutionStatus status = null;
+	
+	private Long lastModified;
+	
+	private Long execDuration;
+	
+	private Float percentLoaded;
+	
+	private int totalSize;
+	
+	List<RundeckOutputEntry> logEntries = null;
+
+	public Long getExecutionId() {
+		return executionId;
+	}
+
+	public void setExecutionId(Long executionId) {
+		this.executionId = executionId;
+	}
+
+	/*public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	public String getError() {
+		return error;
+	}
+
+	public void setError(String error) {
+		this.error = error;
+	}*/
+
+	public Boolean isUnmodified() {
+		return unmodified;
+	}
+
+	public void setUnmodified(Boolean unmodified) {
+		this.unmodified = unmodified;
+	}
+
+	public Boolean isEmpty() {
+		return empty;
+	}
+
+	public void setEmpty(Boolean empty) {
+		this.empty = empty;
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public void setOffset(int offset) {
+		this.offset = offset;
+	}
+
+	public Boolean isCompleted() {
+		return completed;
+	}
+
+	public void setCompleted(Boolean completed) {
+		this.completed = completed;
+	}
+
+	public Boolean isExecCompleted() {
+		return execCompleted;
+	}
+
+	public void setExecCompleted(Boolean execCompleted) {
+		this.execCompleted = execCompleted;
+	}
+
+	public Boolean isHasFailedNodes() {
+		return hasFailedNodes;
+	}
+
+	public void setHasFailedNodes(Boolean hasFailedNodes) {
+		this.hasFailedNodes = hasFailedNodes;
+	}
+
+	public RundeckExecution.ExecutionStatus getStatus() {
+		return status;
+	}
+
+	public void setStatus(RundeckExecution.ExecutionStatus status) {
+		this.status = status;
+	}
+
+	public Long getLastModified() {
+		return lastModified;
+	}
+
+	public void setLastModified(Long lastModified) {
+		this.lastModified = lastModified;
+	}
+
+	public Long getExecDuration() {
+		return execDuration;
+	}
+
+	public void setExecDuration(Long execDuration) {
+		this.execDuration = execDuration;
+	}
+
+	public Float getPercentLoaded() {
+		return percentLoaded;
+	}
+
+	public void setPercentLoaded(Float percentLoaded) {
+		this.percentLoaded = percentLoaded;
+	}
+
+	public int getTotalSize() {
+		return totalSize;
+	}
+
+	public void setTotalSize(int totalSize) {
+		this.totalSize = totalSize;
+	}
+
+	public List<RundeckOutputEntry> getLogEntries() {
+		return logEntries;
+	}
+
+	public void setLogEntries(List<RundeckOutputEntry> logEntries) {
+		this.logEntries = logEntries;
+	}
+	
+	public void addLogEntry(RundeckOutputEntry entry){
+		if(logEntries == null){
+			logEntries = new ArrayList<RundeckOutputEntry>();
+		}
+		logEntries.add(entry);
+	}
+
+    @Override
+    public String toString() {
+        return "RundeckOutput [executionId=" + executionId + /*", message=" + message + 
+        	", error=" + error +*/ ", unmodified=" + unmodified + ", empty=" + empty + 
+        	", offset=" + offset + ", completed=" + completed +
+        	", execCompleted=" + execCompleted + ", hasFailedNodes=" + hasFailedNodes +
+        	", status=" + status + ", lastModified=" + lastModified +
+        	", execDuration=" + execDuration + ", percentLoaded=" + percentLoaded +
+        	", totalSize=" + totalSize + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((executionId == null) ? 0 : executionId.hashCode());
+       // result = prime * result + ((message == null) ? 0 : message.hashCode());
+       // result = prime * result + ((error == null) ? 0 : error.hashCode());
+        result = prime * result + ((unmodified == null) ? 0 : unmodified.hashCode());
+        result = prime * result + ((empty == null) ? 0 : empty.hashCode());
+        result = prime * result + offset;
+        result = prime * result + ((completed == null) ? 0 : completed.hashCode());
+        result = prime * result + ((execCompleted == null) ? 0 : execCompleted.hashCode());
+        result = prime * result + ((hasFailedNodes == null) ? 0 : hasFailedNodes.hashCode());
+        result = prime * result + ((status == null) ? 0 : status.hashCode());
+        result = prime * result + ((lastModified == null) ? 0 : lastModified.hashCode());
+        result = prime * result + ((execDuration == null) ? 0 : execDuration.hashCode());
+        result = prime * result + ((percentLoaded == null) ? 0 : percentLoaded.hashCode());
+        result = prime * result + totalSize;
+        result = prime * result + ((logEntries == null) ? 0 : logEntries.hashCode());
+        return result;
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        RundeckOutput other = (RundeckOutput) obj;
+        if (executionId == null) {
+            if (other.executionId != null)
+                return false;
+        } else if (!executionId.equals(other.executionId))
+            return false;
+/*        if (message == null) {
+            if (other.message != null)
+                return false;
+        } else if (!message.equals(other.message))
+            return false;
+        if (error == null) {
+            if (other.error != null)
+                return false;
+        } else if (!error.equals(other.error))
+            return false;
+*/
+        if (unmodified == null) {
+            if (other.unmodified != null)
+                return false;
+        } else if (!unmodified.equals(other.unmodified))
+            return false;
+        if (empty == null) {
+            if (other.empty != null)
+                return false;
+        } else if (!empty.equals(other.empty))
+            return false;
+        if (offset != other.offset)
+            return false;
+        if (completed == null) {
+            if (other.completed != null)
+                return false;
+        } else if (!completed.equals(other.completed))
+            return false;
+        if (execCompleted == null) {
+            if (other.execCompleted != null)
+                return false;
+        } else if (!execCompleted.equals(other.execCompleted))
+            return false;
+        if (hasFailedNodes == null) {
+            if (other.hasFailedNodes != null)
+                return false;
+        } else if (!hasFailedNodes.equals(other.hasFailedNodes))
+            return false;
+        if (status == null) {
+            if (other.status != null)
+                return false;
+        } else if (!status.equals(other.status))
+            return false;
+        if (lastModified == null) {
+            if (other.lastModified != null)
+                return false;
+        } else if (!lastModified.equals(other.lastModified))
+            return false;
+        if (execDuration == null) {
+            if (other.execDuration != null)
+                return false;
+        } else if (!execDuration.equals(other.execDuration))
+            return false;
+        if (percentLoaded == null) {
+            if (other.percentLoaded != null)
+                return false;
+        } else if (!percentLoaded.equals(other.percentLoaded))
+            return false;
+        if (totalSize != other.totalSize)
+            return false;
+        if (logEntries == null) {
+            if (other.logEntries != null)
+                return false;
+        } else if (!logEntries.equals(other.logEntries))
+            return false;
+        return true;
+    }
+	
+}

--- a/src/main/java/org/rundeck/api/domain/RundeckOutputEntry.java
+++ b/src/main/java/org/rundeck/api/domain/RundeckOutputEntry.java
@@ -1,0 +1,146 @@
+package org.rundeck.api.domain;
+
+import java.io.Serializable;
+
+/**
+ * Represents a RunDeck output entry
+ * 
+ */
+public class RundeckOutputEntry implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private String time = null;
+	
+	private RundeckLogLevel level = null;
+	
+	private String message = null;
+	
+	private String user = null;
+	
+	private String command = null;
+	
+	private String node = null;
+
+
+
+	public String getTime() {
+		return time;
+	}
+
+	public void setTime(String time) {
+		this.time = time;
+	}
+
+	public RundeckLogLevel getLevel() {
+		return level;
+	}
+
+	public void setLevel(RundeckLogLevel level) {
+		this.level = level;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public void setUser(String user) {
+		this.user = user;
+	}
+
+	public String getCommand() {
+		return command;
+	}
+
+	public void setCommand(String command) {
+		this.command = command;
+	}
+
+	public String getNode() {
+		return node;
+	}
+
+	public void setNode(String node) {
+		this.node = node;
+	}
+
+
+
+    @Override
+    public String toString() {
+        return "RundeckOutputEntry [time=" + time + ", level=" + level + 
+        	", message=" + message + ", user=" + user + ", command=" + 
+        	command + ", node=" + node + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((time == null) ? 0 : time.hashCode());
+        result = prime * result + ((level == null) ? 0 : level.hashCode());
+        result = prime * result + ((message == null) ? 0 : message.hashCode());
+        result = prime * result + ((user == null) ? 0 : user.hashCode());
+        result = prime * result + ((command == null) ? 0 : command.hashCode());
+        result = prime * result + ((node == null) ? 0 : node.hashCode());
+        return result;
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        RundeckOutputEntry other = (RundeckOutputEntry) obj;
+        if (time == null) {
+            if (other.time != null)
+                return false;
+        } else if (!time.equals(other.time))
+            return false;
+        if (level == null) {
+            if (other.level != null)
+                return false;
+        } else if (!level.equals(other.level))
+            return false;
+        if (message == null) {
+            if (other.message != null)
+                return false;
+        } else if (!message.equals(other.message))
+            return false;
+        if (user == null) {
+            if (other.user != null)
+                return false;
+        } else if (!user.equals(other.user))
+            return false;
+        if (command == null) {
+            if (other.command != null)
+                return false;
+        } else if (!command.equals(other.command))
+            return false;
+        if (node == null) {
+            if (other.node != null)
+                return false;
+        } else if (!node.equals(other.node))
+            return false;
+        return true;
+    }
+
+
+    public static enum RundeckLogLevel {
+        SEVERE, WARNING, INFO, CONFIG, FINEST;
+    }
+
+
+}

--- a/src/main/java/org/rundeck/api/parser/OutputEntryParser.java
+++ b/src/main/java/org/rundeck/api/parser/OutputEntryParser.java
@@ -1,0 +1,47 @@
+package org.rundeck.api.parser;
+
+import org.apache.commons.lang.StringUtils;
+import org.dom4j.Node;
+
+import org.rundeck.api.domain.RundeckOutputEntry;
+import org.rundeck.api.domain.RundeckOutputEntry.RundeckLogLevel;
+
+public class OutputEntryParser implements XmlNodeParser<RundeckOutputEntry> {
+
+
+    private String xpath;
+
+    public OutputEntryParser() {
+        super();
+    }
+
+    /**
+     * @param xpath of the event element if it is not the root node
+     */
+    public OutputEntryParser(String xpath) {
+        super();
+        this.xpath = xpath;
+    }
+
+    @Override
+    public RundeckOutputEntry parseXmlNode(Node node) {
+        Node entryNode = xpath != null ? node.selectSingleNode(xpath) : node;
+
+        RundeckOutputEntry outputEntry = new RundeckOutputEntry();
+        
+        outputEntry.setTime(StringUtils.trimToNull(entryNode.valueOf("@time")));
+        try {
+    		outputEntry.setLevel(RundeckLogLevel.valueOf(StringUtils.upperCase(entryNode.valueOf("@level"))));
+        } catch (IllegalArgumentException e) {
+            outputEntry.setLevel(null);
+        }
+
+        outputEntry.setUser(StringUtils.trimToNull(entryNode.valueOf("@user")));
+        outputEntry.setCommand(StringUtils.trimToNull(entryNode.valueOf("@command")));
+        outputEntry.setNode(StringUtils.trimToNull(entryNode.valueOf("@node")));
+        outputEntry.setMessage(StringUtils.trimToNull(entryNode.getStringValue()));
+        
+        return outputEntry;
+    }
+
+}

--- a/src/main/java/org/rundeck/api/parser/OutputParser.java
+++ b/src/main/java/org/rundeck/api/parser/OutputParser.java
@@ -1,0 +1,101 @@
+package org.rundeck.api.parser;
+
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.dom4j.Node;
+
+import org.rundeck.api.domain.RundeckOutput;
+import org.rundeck.api.domain.RundeckOutputEntry;
+import org.rundeck.api.domain.RundeckExecution;
+import org.rundeck.api.domain.RundeckExecution.ExecutionStatus;
+
+
+public class OutputParser implements XmlNodeParser<RundeckOutput> {
+
+
+    private String xpath;
+
+    public OutputParser() {
+        super();
+    }
+
+    /**
+     * @param xpath of the event element if it is not the root node
+     */
+    public OutputParser(String xpath) {
+        super();
+        this.xpath = xpath;
+    }
+
+    @Override
+    public RundeckOutput parseXmlNode(Node node) {
+        Node entryNode = xpath != null ? node.selectSingleNode(xpath) : node;
+
+        RundeckOutput output = new RundeckOutput();
+        
+       	//output.setMessage(StringUtils.trimToNull(entryNode.valueOf("message")));
+       	//output.setError(StringUtils.trimToNull(entryNode.valueOf("error")));
+
+
+        try{
+        	output.setExecutionId(Long.valueOf(entryNode.valueOf("id")));
+        } catch (NumberFormatException e) {
+            output.setExecutionId(null);
+        }
+        
+        try{
+	        output.setOffset(Integer.valueOf(entryNode.valueOf("offset")));
+        } catch (NumberFormatException e) {
+            output.setOffset(-1);
+        }
+        
+	    output.setCompleted(Boolean.valueOf(entryNode.valueOf("completed")));
+	    output.setExecCompleted(Boolean.valueOf(entryNode.valueOf("execCompleted")));
+	    output.setHasFailedNodes(Boolean.valueOf(entryNode.valueOf("hasFailedNodes")));
+       
+        try {
+    		output.setStatus(RundeckExecution.ExecutionStatus.valueOf(StringUtils.upperCase(entryNode.valueOf("execState"))));
+        } catch (IllegalArgumentException e) {
+            output.setStatus(null);
+        }
+
+        try{
+        	output.setLastModified(Long.valueOf(entryNode.valueOf("lastModified")));
+        } catch (NumberFormatException e) {
+            output.setLastModified(null);
+        }
+
+        try{
+        	output.setExecDuration(Long.valueOf(entryNode.valueOf("execDuration")));
+        } catch (NumberFormatException e) {
+            output.setExecDuration(null);
+        }
+
+        try{
+        	output.setPercentLoaded(Float.valueOf(entryNode.valueOf("percentLoaded")));
+        } catch (NumberFormatException e) {
+            output.setPercentLoaded(null);
+        }
+
+        try{
+	        output.setTotalSize(Integer.valueOf(entryNode.valueOf("totalSize")));
+        } catch (NumberFormatException e) {
+            output.setTotalSize(-1);
+        }
+        
+        Node entriesListNode = entryNode.selectSingleNode("entries");
+        
+        if(entriesListNode != null){
+        	@SuppressWarnings("unchecked")
+        	List<Node> entries = entriesListNode.selectNodes("entry");
+        	OutputEntryParser entryParser = new OutputEntryParser();
+
+        	for (Node logEntryNode : entries) {
+            	RundeckOutputEntry outputEntry = entryParser.parseXmlNode(logEntryNode);
+            	output.addLogEntry(outputEntry);
+        	}
+        }
+        return output;
+    }
+
+}

--- a/src/test/resources/betamax/tapes/get_projects.yaml
+++ b/src/test/resources/betamax/tapes/get_projects.yaml
@@ -4,11 +4,11 @@ interactions:
 - recorded: 2011-09-18T16:04:45.973Z
   request:
     method: GET
-    uri: http://rundeck.local:4440/api/2/projects
+    uri: http://rundeck.local:4440/api/5/projects
     headers:
       Host: rundeck.local:4440
       Proxy-Connection: Keep-Alive
-      User-Agent: RunDeck API Java Client 2
+      User-Agent: RunDeck API Java Client 5
       X-RunDeck-Auth-Token: PVnN5K3OPc5vduS3uVuVnEsD57pDC5pd
   response:
     status: 200
@@ -17,4 +17,4 @@ interactions:
       Expires: Thu, 01 Jan 1970 00:00:00 GMT
       Server: Jetty(6.1.21)
       Set-Cookie: JSESSIONID=mxrbh6byhvxt;Path=/
-    body: <result success='true' apiversion='2'><projects count='1'><project><name>test</name><description></description></project></projects></result>
+    body: <result success='true' apiversion='5'><projects count='1'><project><name>test</name><description></description></project></projects></result>


### PR DESCRIPTION
Hello Vincent,

I have been working with a client of ours and Rundeck 1.4.4 release candidate:

```
http://build.rundeck.org/job/rundeck-development/
```

This version implements Rundeck API v5 and contains additional support for job logging.

The pull request contains the following changes:
- Introduced new Rundeck Output classes
- Added support for session based authentication
- Added support to obtain the user profile and generate user api token
- Adjustments to refer to v5 api

My forked:

```
https://github.com/connaryscott/rundeck-api-java-client
```

In my bamboo rundeck plugin, I have been able to get the data using the following:

<pre>

    private void logExecutionOutput(int outputLevel) throws TaskException {


       // get the first set of output lines no more than LOG_MAXLINES starting at beginning

       int offset = 0;
       buildLogger.addBuildLogEntry("BEGIN RUNDECK EXECUTION OUTPUT");
       while (true) {
          RundeckOutput rundeckOutput = getRundeckClient().getJobExecutionOutput(getExecutionId(), offset, 0, LOG_MAXLINES);
          if (null == rundeckOutput) {
             buildLogger.addBuildLogEntry("WARNING, no output from job detected, rundeckOutput is null");
             break;
          }

          List<RundeckOutputEntry> listEntries = rundeckOutput.getLogEntries();
          if (null == listEntries) {
             break;
          }
          if (listEntries.size() != 0) {
             RundeckOutputEntry[] rundeckOutputEntries = listEntries.toArray(new RundeckOutputEntry[listEntries.size()]);
             for (int i=0; i<rundeckOutputEntries.length; i++) {
                String message = rundeckOutputEntries[i].getMessage();
                if (outputLevel > LOG_OUT) {
                   buildLogger.addErrorLogEntry(message);
                } else {
                   buildLogger.addBuildLogEntry(message);
                }
                if (null != message) {
                   offset+=message.length();
                }
             }
          }
          if (rundeckOutput.getPercentLoaded() == 1.0) {
             break;
          }
       }
       buildLogger.addBuildLogEntry("END RUNDECK EXECUTION OUTPUT");

    }
</pre>


I need to obtain some test classes for these changes.  Anthony Shortland and I are working with a client who cannot publish their changes to OSS projects and are working on their behalf.  So in addition to your review, we can get them shortly.    

Additionally, it appears that it may be required to release separate versions of your api so that it uses the desired api version of Rundeck?   We can also discuss this with Greg Schueler.

Thanks,

Chuck
